### PR TITLE
Change the .off() function to use .fitlerNot

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'com.google.truth', name: 'truth', version: '0.42'
+    testCompile group: 'org.mockito', name: 'mockito-core', version: '2.19.1'
 
 }
 

--- a/src/main/kotlin/org/phoenixframework/PhxChannel.kt
+++ b/src/main/kotlin/org/phoenixframework/PhxChannel.kt
@@ -5,7 +5,7 @@ import java.lang.IllegalStateException
 
 class PhxChannel(
         val topic: String,
-        var params: Payload,
+        val params: Payload,
         val socket: PhxSocket
 ) {
 
@@ -60,7 +60,7 @@ class PhxChannel(
         this.state = PhxChannel.PhxState.CLOSED
         this.bindings = ArrayList()
         this.bindingRef = 0
-        this.timeout = DEFAULT_TIMEOUT
+        this.timeout = socket.timeout
         this.joinedOnce = false
         this.pushBuffer = ArrayList()
         this.joinPush = PhxPush(this,
@@ -220,7 +220,7 @@ class PhxChannel(
         // Remove any subscriptions that match the given event and ref ID. If no ref
         // ID is given, then remove all subscriptions for an event.
         this.bindings = bindings
-                .filter { it.first == event && (ref == null || ref == it.second) }
+                .filterNot { it.first == event && (ref == null || ref == it.second) }
                 .toMutableList()
     }
 
@@ -300,7 +300,7 @@ class PhxChannel(
     // Internal
     //------------------------------------------------------------------------------
     /** Checks if an event received by the socket belongs to the Channel */
-    fun isMemeber(message: PhxMessage): Boolean {
+    fun isMember(message: PhxMessage): Boolean {
         if (message.topic != this.topic) { return false }
 
         val isLifecycleEvent = PhxEvent.isLifecycleEvent(message.event)

--- a/src/main/kotlin/org/phoenixframework/PhxSocket.kt
+++ b/src/main/kotlin/org/phoenixframework/PhxSocket.kt
@@ -23,7 +23,7 @@ const val DEFAULT_TIMEOUT: Long = 10000
 /** Default heartbeat interval set to 30s */
 const val DEFAULT_HEARTBEAT: Long = 30000
 
-class PhxSocket(
+open class PhxSocket(
         url: String,
         params: Payload? = null
 ) : WebSocketListener() {
@@ -259,7 +259,7 @@ class PhxSocket(
     /**
      * Sends data through the Socket
      */
-    public fun push(topic: String,
+    public open fun push(topic: String,
                     event: String,
                     payload: Payload,
                     ref: String? = null,
@@ -295,7 +295,7 @@ class PhxSocket(
     /**
      * @return the next message ref, accounting for overflows
      */
-    public fun makeRef(): String {
+    public open fun makeRef(): String {
         val newRef = this.ref + 1
         this.ref = if (newRef == Int.MAX_VALUE) 0 else newRef
 
@@ -363,7 +363,7 @@ class PhxSocket(
 
         // Dispatch the message to all channels that belong to the topic
         this.channels
-                .filter { it.isMemeber(message) }
+                .filter { it.isMember(message) }
                 .forEach { it.trigger(message) }
 
         // Inform all onMessage callbacks of the message

--- a/src/test/kotlin/org/phoenixframework/PhxChannelTest.kt
+++ b/src/test/kotlin/org/phoenixframework/PhxChannelTest.kt
@@ -1,0 +1,128 @@
+package org.phoenixframework
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito
+import org.mockito.MockitoAnnotations
+import org.mockito.Spy
+
+class PhxChannelTest {
+
+    private val defaultRef = "1"
+
+    @Spy
+    var socket: PhxSocket = PhxSocket("http://localhost:4000/socket/websocket")
+    lateinit var channel: PhxChannel
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.initMocks(this)
+        Mockito.doReturn(defaultRef).`when`(socket).makeRef()
+
+        socket.timeout = 1234
+        channel = PhxChannel("topic", hashMapOf("one" to "two"), socket)
+    }
+
+
+    //------------------------------------------------------------------------------
+    // Constructor
+    //------------------------------------------------------------------------------
+    @Test
+    fun `constructor sets defaults`() {
+        assertThat(channel.isClosed).isTrue()
+        assertThat(channel.topic).isEqualTo("topic")
+        assertThat(channel.params["one"]).isEqualTo("two")
+        assertThat(channel.socket).isEqualTo(socket)
+        assertThat(channel.timeout).isEqualTo(1234)
+        assertThat(channel.joinedOnce).isFalse()
+        assertThat(channel.pushBuffer).isEmpty()
+    }
+
+    @Test
+    fun `constructor sets up joinPush with params`() {
+        val joinPush = channel.joinPush
+
+        assertThat(joinPush.channel).isEqualTo(channel)
+        assertThat(joinPush.payload["one"]).isEqualTo("two")
+        assertThat(joinPush.event).isEqualTo(PhxChannel.PhxEvent.JOIN.value)
+        assertThat(joinPush.timeout).isEqualTo(1234)
+    }
+
+
+    //------------------------------------------------------------------------------
+    // Join
+    //------------------------------------------------------------------------------
+    @Test
+    fun `it sets the state to joining`() {
+        channel.join()
+        assertThat(channel.isJoining).isTrue()
+    }
+
+    @Test
+    fun `it updates the join parameters`() {
+        channel.join(hashMapOf("one" to "three"))
+
+        val joinPush = channel.joinPush
+        assertThat(joinPush.payload["one"]).isEqualTo("three")
+    }
+
+    @Test
+    fun `it sets joinedOnce to true`() {
+        assertThat(channel.joinedOnce).isFalse()
+
+        channel.join()
+        assertThat(channel.joinedOnce).isTrue()
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `it throws if attempting to join multiple times`() {
+        channel.join()
+        channel.join()
+    }
+
+
+
+    //------------------------------------------------------------------------------
+    // .off()
+    //------------------------------------------------------------------------------
+    @Test
+    fun `it removes all callbacks for events`() {
+        Mockito.doReturn(defaultRef).`when`(socket).makeRef()
+
+        var aCalled = false
+        var bCalled = false
+        var cCalled = false
+
+        channel.on("event") { aCalled = true }
+        channel.on("event") { bCalled = true }
+        channel.on("other") { cCalled = true }
+
+        channel.off("event")
+
+        channel.trigger(PhxMessage(event = "event", ref = defaultRef))
+        channel.trigger(PhxMessage(event = "other", ref = defaultRef))
+
+        assertThat(aCalled).isFalse()
+        assertThat(bCalled).isFalse()
+        assertThat(cCalled).isTrue()
+    }
+
+    @Test
+    fun `it removes callbacks by its ref`() {
+        var aCalled = false
+        var bCalled = false
+
+        val aRef = channel.on("event") { aCalled = true }
+        channel.on("event") { bCalled = true }
+
+
+        channel.off("event", aRef)
+
+        channel.trigger(PhxMessage(event = "event", ref = defaultRef))
+
+        assertThat(aCalled).isFalse()
+        assertThat(bCalled).isTrue()
+    }
+}
+


### PR DESCRIPTION
Closes #5 

* Fixed the `.off()` method which needed to used `.filterNot` instead of `.filter` in order to remove the single handler instead of all other handlers by using the `.filterNot` closure instead
* Added some tests for the `.off()` method
* Added some other tests for the Channel class