### PR TITLE
NoClassDefFoundError fix

### DIFF
--- a/src/main/kotlin/org/phoenixframework/PhxSocket.kt
+++ b/src/main/kotlin/org/phoenixframework/PhxSocket.kt
@@ -120,7 +120,7 @@ open class PhxSocket(
         // If there are query params, append them now
         params?.let {
             val httpBuilder = httpUrl.newBuilder()
-            it.forEach { key, value ->
+            it.forEach { (key, value) ->
                 httpBuilder.addQueryParameter(key, value.toString())
             }
 


### PR DESCRIPTION
On pre API 24 devices, it crashes with NoClassDefFoundError