### PR TITLE
Initialize reconnectTimer in PhxSocket

### DIFF
--- a/src/main/kotlin/org/phoenixframework/PhxSocket.kt
+++ b/src/main/kotlin/org/phoenixframework/PhxSocket.kt
@@ -127,6 +127,14 @@ open class PhxSocket(
             httpUrl = httpBuilder.build()
         }
 
+        reconnectTimer = PhxTimer(
+            callback = {
+                disconnect().also {
+                    connect()
+                }
+            },
+            timerCalculation = reconnectAfterMs
+        )
 
         // Hold reference to where the Socket is pointing to
         this.endpoint = httpUrl.url()


### PR DESCRIPTION
Fixing `autoReconnect` feature. The `reconnectTimer` was always null so it basically didn't work at all. 