### PR TITLE
Downgrade okhttp to 3.12.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
 dependencies {
   compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
   compile "com.google.code.gson:gson:2.8.5"
-  compile "com.squareup.okhttp3:okhttp:3.14.1"
+  compile "com.squareup.okhttp3:okhttp:3.12.2"
 
 
   testCompile group: 'junit', name: 'junit', version: '4.12'


### PR DESCRIPTION
3.13.0 requires min target to Android 5.0. Client should still provide support for pre-5.0 devices

Release article here: https://medium.com/square-corner-blog/okhttp-3-13-requires-android-5-818bb78d07ce