### PR TITLE
Fix WebSocketTransport not kicking off reconnect strategy

### DIFF
--- a/src/main/kotlin/org/phoenixframework/Socket.kt
+++ b/src/main/kotlin/org/phoenixframework/Socket.kt
@@ -51,6 +51,12 @@ internal data class StateChangeCallbacks(
 /** The code used when the socket was closed without error */
 const val WS_CLOSE_NORMAL = 1000
 
+/** The socket was closed due to a SocketException. Likely the client lost connectivity */
+const val WS_CLOSE_SOCKET_EXCEPTION = 4000
+
+/** The socket was closed due to an EOFException. Likely the server abruptly closed */
+const val WS_CLOSE_EOF_EXCEPTION = 4001
+
 /**
  * Connects to a Phoenix Server
  */


### PR DESCRIPTION
The WebSocketTransport always `errored` whenever connectivity was lost, never properly closing the `Socket`, thus never kicking off the reconnect behavior. OkHttp throws EOFException if the server closes unexpectedly and a SocketException if the client loses connectivity. In both of these cases, make sure `onClose` is called to attempt to reconnect. 