### PR TITLE
Moving heartbeat task to repeat at fixed rate

### DIFF
--- a/src/main/kotlin/org/phoenixframework/DispatchQueue.kt
+++ b/src/main/kotlin/org/phoenixframework/DispatchQueue.kt
@@ -36,6 +36,13 @@ import java.util.concurrent.TimeUnit
 interface DispatchQueue {
   /** Queue a Runnable to be executed after a given time unit delay */
   fun queue(delay: Long, unit: TimeUnit, runnable: () -> Unit): DispatchWorkItem
+
+  /**
+   * Creates and executes a periodic action that becomes enabled first after the given initial
+   * delay, and subsequently with the given period; that is, executions will commence after
+   * initialDelay, then initialDelay + period, then initialDelay + 2 * period, and so on.
+   */
+  fun queueAtFixedRate(delay: Long, period: Long, unit: TimeUnit, runnable: () -> Unit): DispatchWorkItem
 }
 
 /** Abstracts away a future task */
@@ -62,6 +69,16 @@ class ScheduledDispatchQueue(poolSize: Int = 8) : DispatchQueue {
 
   override fun queue(delay: Long, unit: TimeUnit, runnable: () -> Unit): DispatchWorkItem {
     val scheduledFuture = scheduledThreadPoolExecutor.schedule(runnable, delay, unit)
+    return ScheduledDispatchWorkItem(scheduledFuture)
+  }
+
+  override fun queueAtFixedRate(
+    delay: Long,
+    period: Long,
+    unit: TimeUnit,
+    runnable: () -> Unit
+  ): DispatchWorkItem {
+    val scheduledFuture = scheduledThreadPoolExecutor.scheduleAtFixedRate(runnable, delay, period, unit)
     return ScheduledDispatchWorkItem(scheduledFuture)
   }
 }

--- a/src/main/kotlin/org/phoenixframework/Socket.kt
+++ b/src/main/kotlin/org/phoenixframework/Socket.kt
@@ -54,11 +54,6 @@ const val WS_CLOSE_NORMAL = 1000
 /** The socket was closed due to a SocketException. Likely the client lost connectivity */
 const val WS_CLOSE_SOCKET_EXCEPTION = 4000
 
-/** The socket was closed due to an SSLException. Likely the client lost connectivity */
-const val WS_CLOSE_SSL_EXCEPTION = 4001
-
-/** The socket was closed due to an EOFException. Likely the server abruptly closed */
-const val WS_CLOSE_EOF_EXCEPTION = 4002
 
 /**
  * Connects to a Phoenix Server
@@ -366,8 +361,11 @@ class Socket(
 
     // Do not start up the heartbeat timer if skipHeartbeat is true
     if (skipHeartbeat) return
+    val delay = heartbeatInterval
+    val period = heartbeatInterval
+
     heartbeatTask =
-        dispatchQueue.queue(heartbeatInterval, TimeUnit.MILLISECONDS) { sendHeartbeat() }
+        dispatchQueue.queueAtFixedRate(delay, period, TimeUnit.MILLISECONDS) { sendHeartbeat() }
   }
 
   internal fun sendHeartbeat() {

--- a/src/test/kotlin/org/phoenixframework/SocketTest.kt
+++ b/src/test/kotlin/org/phoenixframework/SocketTest.kt
@@ -503,7 +503,7 @@ class SocketTest {
 
     socket.onConnectionOpened()
     verify(mockTask).cancel()
-    verify(mockDispatchQueue).queue(any(), any(), any())
+    verify(mockDispatchQueue).queueAtFixedRate(any(), any(), any(), any())
   }
 
   @Test
@@ -541,7 +541,7 @@ class SocketTest {
   @Test
   fun `resetHeartbeat() creates a future heartbeat task`() {
     val mockTask = mock<DispatchWorkItem>()
-    whenever(mockDispatchQueue.queue(any(), any(), any())).thenReturn(mockTask)
+    whenever(mockDispatchQueue.queueAtFixedRate(any(), any(), any(), any())).thenReturn(mockTask)
 
     whenever(connection.readyState).thenReturn(Transport.ReadyState.OPEN)
     socket.connect()
@@ -552,7 +552,7 @@ class SocketTest {
 
     assertThat(socket.heartbeatTask).isNotNull()
     argumentCaptor<() -> Unit> {
-      verify(mockDispatchQueue).queue(eq(5_000L), eq(TimeUnit.MILLISECONDS), capture())
+      verify(mockDispatchQueue).queueAtFixedRate(eq(5_000L), eq(5_000L), eq(TimeUnit.MILLISECONDS), capture())
 
       // fire the task
       allValues.first().invoke()

--- a/src/test/kotlin/org/phoenixframework/WebSocketTransportTest.kt
+++ b/src/test/kotlin/org/phoenixframework/WebSocketTransportTest.kt
@@ -107,7 +107,7 @@ class WebSocketTransportTest {
     val throwable = SSLException("t")
     transport.onFailure(mockWebSocket, throwable, mockResponse)
     verify(mockOnError).invoke(throwable, mockResponse)
-    verify(mockOnClose).invoke(4001)
+    verify(mockOnClose).invoke(4000)
   }
 
   @Test
@@ -120,7 +120,7 @@ class WebSocketTransportTest {
     val throwable = EOFException()
     transport.onFailure(mockWebSocket, throwable, mockResponse)
     verify(mockOnError).invoke(throwable, mockResponse)
-    verify(mockOnClose).invoke(4002)
+    verify(mockOnClose).invoke(4000)
   }
 
   @Test


### PR DESCRIPTION
closes #51 

Heartbeat Task was being scheduled using `ScheduleExecuterService.schedule(delay:)` which is schedules a one-time task. It needs to be scheduled using `ScheduleExecuterService. scheduleAtFixedRate(delay:, period:)` which will repeat the task every given `period` until canceled

* Updated DispatchQueue interface to allow for queueing a repeating task
* Updated Socket to queue the `heartbeatTask` using the new repeating task
* Updated ManualDispatchQueue to implement the new interface method
* Updated tests to ensure that the `heartbeatTask` is scheduled correctly