### PR TITLE
Calling of Java 8 method throws a runtime error in Android API < 24

### DIFF
--- a/src/main/kotlin/org/phoenixframework/Presence.kt
+++ b/src/main/kotlin/org/phoenixframework/Presence.kt
@@ -268,7 +268,7 @@ class Presence(channel: Channel, opts: Options = Options.defaults) {
       val state = cloneState(currentState)
 
       // Sync the joined states and inform onJoin of new presence
-      diff["joins"]?.forEach { key, newPresence ->
+      diff["joins"]?.forEach { (key, newPresence) ->
         val currentPresence = state[key]
         state[key] = cloneMap(newPresence)
 
@@ -288,7 +288,7 @@ class Presence(channel: Channel, opts: Options = Options.defaults) {
       }
 
       // Sync the left diff and inform onLeave of left presence
-      diff["leaves"]?.forEach { key, leftPresence ->
+      diff["leaves"]?.forEach { (key, leftPresence) ->
         val curPresence = state[key] ?: return@forEach
 
         val refsToRemove = leftPresence["metas"]!!.map { it["phx_ref"] as String }


### PR DESCRIPTION
I was seeing a crash on older Android devices and it turned out to be a subtle [destructuring-related issue](https://blog.danlew.net/2017/03/16/kotlin-puzzler-whose-line-is-it-anyways/).

It's pretty easy to reproduce as long as you have the right device (anything less than API 24). I was seeing the exception in the error handling function I register with [setDefaultUncaughtExceptionHandler](https://docs.oracle.com/javase/7/docs/api/java/lang/Thread.html#setDefaultUncaughtExceptionHandler(java.lang.Thread.UncaughtExceptionHandler)), but if you don't register I expect the app would just crash.

I can't think of a good way to add a unit test because of the platform dependency.