### PR TITLE
Optimize Socket Reconnect

### DIFF
--- a/src/main/kotlin/org/phoenixframework/Defaults.kt
+++ b/src/main/kotlin/org/phoenixframework/Defaults.kt
@@ -36,8 +36,19 @@ object Defaults {
 
   /** Default reconnect algorithm. Reconnects after 1s, 2s, 5s and then 10s thereafter */
   val steppedBackOff: (Int) -> Long = { tries ->
-    if (tries > 3) 10000 else listOf(1000L, 2000L, 5000L)[tries - 1]
+    if (tries > 3) 10_000 else listOf(1_000L, 2_000L, 5_000L)[tries - 1]
   }
+
+  /** Default reconnect algorithm for the socket */
+  val reconnectAfterMs: (Int) -> Long = { tries ->
+    if (tries > 9) 5_000 else listOf(10L, 50L, 100L, 150L, 200L, 250L, 500L, 1_000L, 2_000L)[tries - 1]
+  }
+
+  /** Default rejoin algorithm for individual channels */
+  val rejoinAfterMs: (Int) -> Long = { tries ->
+    if (tries > 3) 10_000 else listOf(1_000L, 2_000L, 5_000L)[tries - 1]
+  }
+
 
   /** The default Gson configuration to use when parsing messages */
   val gson: Gson

--- a/src/main/kotlin/org/phoenixframework/Defaults.kt
+++ b/src/main/kotlin/org/phoenixframework/Defaults.kt
@@ -40,12 +40,12 @@ object Defaults {
   }
 
   /** Default reconnect algorithm for the socket */
-  val reconnectAfterMs: (Int) -> Long = { tries ->
+  val reconnectSteppedBackOff: (Int) -> Long = { tries ->
     if (tries > 9) 5_000 else listOf(10L, 50L, 100L, 150L, 200L, 250L, 500L, 1_000L, 2_000L)[tries - 1]
   }
 
   /** Default rejoin algorithm for individual channels */
-  val rejoinAfterMs: (Int) -> Long = { tries ->
+  val rejoinSteppedBackOff: (Int) -> Long = { tries ->
     if (tries > 3) 10_000 else listOf(1_000L, 2_000L, 5_000L)[tries - 1]
   }
 

--- a/src/main/kotlin/org/phoenixframework/Socket.kt
+++ b/src/main/kotlin/org/phoenixframework/Socket.kt
@@ -48,14 +48,15 @@ internal data class StateChangeCallbacks(
   }
 }
 
-/** The code used when the socket was closed without error */
+/** RFC 6455: indicates a normal closure */
 const val WS_CLOSE_NORMAL = 1000
 
-
+/** RFC 6455: indicates that the connection was closed abnormally */
+const val WS_CLOSE_ABNORMAL = 1006
 
 /** The socket was closed due to a SocketException. Likely the client lost connectivity */
+// DEPRECATED
 const val WS_CLOSE_SOCKET_EXCEPTION = 4000
-
 
 /**
  * Connects to a Phoenix Server
@@ -90,11 +91,14 @@ class Socket(
   /** Timeout to use when opening a connection */
   var timeout: Long = Defaults.TIMEOUT
 
-  /** Interval between sending a heartbeat */
-  var heartbeatInterval: Long = Defaults.HEARTBEAT
+  /** Interval between sending a heartbeat, in ms */
+  var heartbeatIntervalMs: Long = Defaults.HEARTBEAT
 
-  /** Internval between socket reconnect attempts */
-  var reconnectAfterMs: ((Int) -> Long) = Defaults.steppedBackOff
+  /** Interval between socket reconnect attempts, in ms */
+  var reconnectAfterMs: ((Int) -> Long) = Defaults.reconnectSteppedBackOff
+
+  /** Interval between channel rejoin attempts, in ms */
+  var rejoinAfterMs: ((Int) -> Long) = Defaults.rejoinSteppedBackOff
 
   /** The optional function to receive logs */
   var logger: ((String) -> Unit)? = null
@@ -141,8 +145,8 @@ class Socket(
   /** Timer to use when attempting to reconnect */
   internal var reconnectTimer: TimeoutTimer
 
-  /** True if the socket closed cleanly. False if it was closed due to an error or timeout */
-  internal var closeWasClean: Boolean = false
+  /** True if the Socket closed cleaned. False if not (connection timeout, heartbeat, etc) */
+  internal var closeWasClean = false
 
   //------------------------------------------------------------------------------
   // Connection Attributes
@@ -223,6 +227,9 @@ class Socket(
     // Do not attempt to connect if already connected
     if (isConnected) return
 
+    // Reset the clean close flag when attempting to connect
+    this.closeWasClean = false
+
     this.connection = this.transport(endpointUrl)
     this.connection?.onOpen = { onConnectionOpened() }
     this.connection?.onClose = { code -> onConnectionClosed(code) }
@@ -236,6 +243,10 @@ class Socket(
     reason: String? = null,
     callback: (() -> Unit)? = null
   ) {
+    // The socket was closed cleanly by the User
+    this.closeWasClean = true
+
+    // Reset any reconnects and teardown the socket connection
     this.reconnectTimer.reset()
     this.teardown(code, reason, callback)
 
@@ -344,7 +355,12 @@ class Socket(
 
   /** Triggers an error event to all connected Channels */
   private fun triggerChannelError() {
-    this.channels.forEach { it.trigger(Channel.Event.ERROR.value) }
+    this.channels.forEach { channel ->
+      // Only trigger a channel error if it is in an "opened" state
+      if (!(channel.isErrored || channel.isLeaving || channel.isClosed)) {
+        channel.trigger(Channel.Event.ERROR.value)
+      }
+    }
   }
 
   /** Send all messages that were buffered before the socket opened */
@@ -366,8 +382,8 @@ class Socket(
 
     // Do not start up the heartbeat timer if skipHeartbeat is true
     if (skipHeartbeat) return
-    val delay = heartbeatInterval
-    val period = heartbeatInterval
+    val delay = heartbeatIntervalMs
+    val period = heartbeatIntervalMs
 
     heartbeatTask =
         dispatchQueue.queueAtFixedRate(delay, period, TimeUnit.MILLISECONDS) { sendHeartbeat() }
@@ -384,9 +400,8 @@ class Socket(
       pendingHeartbeatRef = null
       logItems("Transport: Heartbeat timeout. Attempt to re-establish connection")
 
-      // Disconnect the socket manually. Do not use `teardown` or
-      // `disconnect` as they will nil out the websocket delegate
-      this.connection?.disconnect(WS_CLOSE_NORMAL, "Heartbeat timed out")
+      // Close the socket, flagging the closure as abnormal
+      this.abnormalClose("heartbeat timeout")
       return
     }
 
@@ -399,11 +414,19 @@ class Socket(
         ref = pendingHeartbeatRef)
   }
 
+  internal fun abnormalClose(reason: String) {
+    this.closeWasClean = false
+    this.connection?.disconnect(WS_CLOSE_NORMAL, reason)
+  }
+
   //------------------------------------------------------------------------------
   // Connection Transport Hooks
   //------------------------------------------------------------------------------
   internal fun onConnectionOpened() {
     this.logItems("Transport: Connected to $endpoint")
+
+    // Reset the closeWasClean flag now that the socket has been connected
+    this.closeWasClean = false
 
     // Send any messages that were waiting for a connection
     this.flushSendBuffer()
@@ -426,14 +449,13 @@ class Socket(
     this.heartbeatTask?.cancel()
     this.heartbeatTask = null
 
+    // Only attempt to reconnect if the socket did not close normally
+    if (!this.closeWasClean) {
+      this.reconnectTimer.scheduleTimeout()
+    }
+
     // Inform callbacks the socket closed
     this.stateChangeCallbacks.close.forEach { it.invoke() }
-
-    // If there was a non-normal event when the connection closed, attempt
-    // to schedule a reconnect attempt
-    if (code != WS_CLOSE_NORMAL) {
-      reconnectTimer.scheduleTimeout()
-    }
   }
 
   internal fun onConnectionMessage(rawMessage: String) {

--- a/src/main/kotlin/org/phoenixframework/Socket.kt
+++ b/src/main/kotlin/org/phoenixframework/Socket.kt
@@ -54,9 +54,6 @@ const val WS_CLOSE_NORMAL = 1000
 /** RFC 6455: indicates that the connection was closed abnormally */
 const val WS_CLOSE_ABNORMAL = 1006
 
-/** The socket was closed due to a SocketException. Likely the client lost connectivity */
-// DEPRECATED
-const val WS_CLOSE_SOCKET_EXCEPTION = 4000
 
 /**
  * Connects to a Phoenix Server
@@ -414,8 +411,14 @@ class Socket(
         ref = pendingHeartbeatRef)
   }
 
-  internal fun abnormalClose(reason: String) {
+  private fun abnormalClose(reason: String) {
     this.closeWasClean = false
+
+    /*
+      We use NORMAL here since the client is the one determining to close the connection. However,
+      we keep a flag `closeWasClean` set to false so that the client knows that it should attempt
+      to reconnect.
+     */
     this.connection?.disconnect(WS_CLOSE_NORMAL, reason)
   }
 

--- a/src/main/kotlin/org/phoenixframework/Socket.kt
+++ b/src/main/kotlin/org/phoenixframework/Socket.kt
@@ -51,6 +51,8 @@ internal data class StateChangeCallbacks(
 /** The code used when the socket was closed without error */
 const val WS_CLOSE_NORMAL = 1000
 
+
+
 /** The socket was closed due to a SocketException. Likely the client lost connectivity */
 const val WS_CLOSE_SOCKET_EXCEPTION = 4000
 
@@ -138,6 +140,9 @@ class Socket(
 
   /** Timer to use when attempting to reconnect */
   internal var reconnectTimer: TimeoutTimer
+
+  /** True if the socket closed cleanly. False if it was closed due to an error or timeout */
+  internal var closeWasClean: Boolean = false
 
   //------------------------------------------------------------------------------
   // Connection Attributes

--- a/src/test/kotlin/org/phoenixframework/SocketTest.kt
+++ b/src/test/kotlin/org/phoenixframework/SocketTest.kt
@@ -295,6 +295,14 @@ class SocketTest {
     }
 
     @Test
+    internal fun `flags the socket as closed cleanly`() {
+      assertThat(socket.closeWasClean).isFalse()
+
+      socket.disconnect()
+      assertThat(socket.closeWasClean).isTrue()
+    }
+
+    @Test
     internal fun `calls callback`() {
       val mockCallback = mock<() -> Unit> {}
 

--- a/src/test/kotlin/org/phoenixframework/WebSocketTransportTest.kt
+++ b/src/test/kotlin/org/phoenixframework/WebSocketTransportTest.kt
@@ -14,8 +14,6 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
-import org.phoenixframework.Transport
-import org.phoenixframework.WebSocketTransport
 import java.net.SocketException
 import java.net.URL
 
@@ -124,7 +122,7 @@ class WebSocketTransportTest {
       val throwable = SocketException()
       transport.onFailure(mockWebSocket, throwable, mockResponse)
       verify(mockOnError).invoke(throwable, mockResponse)
-      verify(mockOnClose).invoke(4000)
+      verify(mockOnClose).invoke(1006)
     }
 
     /* End OnFailure */


### PR DESCRIPTION

* Use a more aggressive reconnect algorithm 
* decouple socket reconnect algorithm with channel rejoin, socket side. Channel changes next
* Fix socket never reconnecting after a heartbeat times out
* Updated WebSocketTransport to call `onClose` after an `onError` event