### PR TITLE
Prevent entering a rejoin loop if channel leaves before joined

### DIFF
--- a/src/main/kotlin/org/phoenixframework/Channel.kt
+++ b/src/main/kotlin/org/phoenixframework/Channel.kt
@@ -320,6 +320,9 @@ class Channel(
     // If attempting a rejoin during a leave, then reset, cancelling the rejoin
     this.rejoinTimer.reset()
 
+    // Prevent entering a rejoin loop if leaving a channel before joined
+    this.joinPush.cancelTimeout()
+
     // Now set the state to leaving
     this.state = State.LEAVING
 

--- a/src/main/kotlin/org/phoenixframework/Push.kt
+++ b/src/main/kotlin/org/phoenixframework/Push.kt
@@ -177,7 +177,7 @@ class Push(
   }
 
   /** Cancels any ongoing timeout task */
-  private fun cancelTimeout() {
+  internal fun cancelTimeout() {
     this.timeoutTask?.cancel()
     this.timeoutTask = null
   }

--- a/src/test/kotlin/org/phoenixframework/ChannelTest.kt
+++ b/src/test/kotlin/org/phoenixframework/ChannelTest.kt
@@ -314,6 +314,19 @@ class ChannelTest {
         assertThat(channel.state).isEqualTo(Channel.State.JOINED)
       }
 
+
+      @Test
+      internal fun `does not enter rejoin loop if leave is called before joined`() {
+        socket.connect()
+        this.receiveSocketOpen()
+
+        channel.join()
+        channel.leave()
+
+        fakeClock.tick(channel.timeout * 4)
+        verify(socket, times(2)).push(any(), any(), any(), any(), any())
+      }
+
       /* End TimeoutBehavior */
     }
 
@@ -1042,6 +1055,7 @@ class ChannelTest {
       channel.leave()
       assertThat(channel.state).isEqualTo(Channel.State.CLOSED)
     }
+
     /* End Leave */
   }
 


### PR DESCRIPTION
Immediately leaving a channel after calling join would enter a rejoin loop.

```Kotlin
channel.join()
channel.leave()
```

Fixed by canceling the `joinPush` timeout when `leaving` the channel