### PR TITLE
Changed Presence leave join callback order to better match expected event order

### DIFF
--- a/src/main/kotlin/org/phoenixframework/Presence.kt
+++ b/src/main/kotlin/org/phoenixframework/Presence.kt
@@ -268,7 +268,7 @@ class Presence(channel: Channel, opts: Options = Options.defaults) {
       val state = cloneState(currentState)
 
       // Sync the joined states and inform onJoin of new presence
-      diff["joins"]?.forEach { key, newPresence ->
+      diff["joins"]?.forEach { (key, newPresence) ->
         val currentPresence = state[key]
         state[key] = cloneMap(newPresence)
 
@@ -288,7 +288,7 @@ class Presence(channel: Channel, opts: Options = Options.defaults) {
       }
 
       // Sync the left diff and inform onLeave of left presence
-      diff["leaves"]?.forEach { key, leftPresence ->
+      diff["leaves"]?.forEach { (key, leftPresence) ->
         val curPresence = state[key] ?: return@forEach
 
         val refsToRemove = leftPresence["metas"]!!.map { it["phx_ref"] as String }


### PR DESCRIPTION
There [appears to be a convention](https://github.com/phoenixframework/phoenix/issues/1639#issuecomment-208433900) that when updating the properties associated with a Presence it should _leave_ then _join_. I was slightly surprised that there isn't a less radical "property update event" of some kind, but I guess this could be added if required by a client?

Either way, it is assumed that the _leave_ and _join_ events will be processed in the order they are given in the JSON packet, but this is not the case currently in JavaPhoenixClient, which always processes _join_ first. This can lead to clients processing the _join_ and then erroneously removing the Presence when processing the _leave_.

The PR is only a band-aid solution as it doesn't actually process the events in the JSON order, but just in _leave-join_ order to fix the immediate problem. Feel free to reject in favour of something more comprehensive.

For reference, I came across the problem when connecting to Mozilla Hubs, which has this exact behaviour when updating properties like _displayName_ or _avatarId_.