### PR TITLE
Fixed concurrent exception

### DIFF
--- a/src/main/kotlin/org/phoenixframework/Socket.kt
+++ b/src/main/kotlin/org/phoenixframework/Socket.kt
@@ -277,7 +277,12 @@ class Socket(
   }
 
   fun remove(channel: Channel) {
-    this.channels.removeAll { it.joinRef == channel.joinRef }
+    // To avoid a ConcurrentModificationException, filter out the channels to be
+    // removed instead of calling .remove() on the list, thus returning a new list
+    // that does not contain the channel that was removed.
+    this.channels = channels
+        .filter { it.joinRef != channel.joinRef }
+        .toMutableList()
   }
 
   //------------------------------------------------------------------------------


### PR DESCRIPTION
Do not use `.removeAll {}` when removing a Channel, instead, filter out the channels that are to be removed. This aligns more closely to how the js client removes a Channel from a Socket and avoids a ConcurrentModificationException without messing up ongoing iterators.