### PR TITLE
Fix Concurrency issues with StateChange hooks and add/removing channels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+dist: trusty
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 jdk:

--- a/src/main/kotlin/org/phoenixframework/Push.kt
+++ b/src/main/kotlin/org/phoenixframework/Push.kt
@@ -45,7 +45,7 @@ class Push(
   var timeoutTask: DispatchWorkItem? = null
 
   /** Hooks into a Push. Where .receive("ok", callback(Payload)) are stored */
-  var receiveHooks: MutableMap<String, MutableList<((message: Message) -> Unit)>> = HashMap()
+  var receiveHooks: MutableMap<String, List<((message: Message) -> Unit)>> = HashMap()
 
   /** True if the Push has been sent */
   var sent: Boolean = false
@@ -93,13 +93,9 @@ class Push(
     // If the message has already be received, pass it to the callback
     receivedMessage?.let { if (hasReceived(status)) callback(it) }
 
-    if (receiveHooks[status] == null) {
-      // Create a new array of hooks if no previous hook is associated with status
-      receiveHooks[status] = arrayListOf(callback)
-    } else {
-      // A previous hook for this status already exists. Just append the new hook
-      receiveHooks[status]?.add(callback)
-    }
+    // If a previous hook for this status already exists. Just append the new hook. If not, then
+    // create a new array of hooks if no previous hook is associated with status
+    receiveHooks[status] = receiveHooks[status]?.copyAndAdd(callback) ?: arrayListOf(callback)
 
     return this
   }

--- a/src/main/kotlin/org/phoenixframework/Socket.kt
+++ b/src/main/kotlin/org/phoenixframework/Socket.kt
@@ -304,7 +304,7 @@ class Socket(
 
   fun channel(topic: String, params: Payload = mapOf()): Channel {
     val channel = Channel(topic, params, this)
-    this.channels.copyAndAdd(channel)
+    this.channels = this.channels.copyAndAdd(channel)
 
     return channel
   }

--- a/src/test/kotlin/org/phoenixframework/SocketTest.kt
+++ b/src/test/kotlin/org/phoenixframework/SocketTest.kt
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
+import org.phoenixframework.utilities.copyAndRemove
 import java.net.URL
 import java.util.concurrent.TimeUnit
 
@@ -755,8 +756,8 @@ class SocketTest {
       val spy = spy(channel)
 
       // Use the spy instance instead of the Channel instance
-      socket.channels.remove(channel)
-      socket.channels.add(spy)
+      socket.channels = socket.channels.copyAndRemove(channel)
+      socket.channels = socket.channels.copyAndAdd(spy)
 
       spy.join()
       assertThat(spy.state).isEqualTo(Channel.State.JOINING)
@@ -771,8 +772,8 @@ class SocketTest {
       val spy = spy(channel)
 
       // Use the spy instance instead of the Channel instance
-      socket.channels.remove(channel)
-      socket.channels.add(spy)
+      socket.channels = socket.channels.copyAndRemove(channel)
+      socket.channels = socket.channels.copyAndAdd(spy)
 
       spy.join().trigger("ok", emptyMap())
 
@@ -788,8 +789,8 @@ class SocketTest {
       val spy = spy(channel)
 
       // Use the spy instance instead of the Channel instance
-      socket.channels.remove(channel)
-      socket.channels.add(spy)
+      socket.channels = socket.channels.copyAndRemove(channel)
+      socket.channels = socket.channels.copyAndAdd(spy)
 
       spy.join().trigger("ok", emptyMap())
       spy.leave()
@@ -827,8 +828,8 @@ class SocketTest {
       val spy = spy(channel)
 
       // Use the spy instance instead of the Channel instance
-      socket.channels.remove(channel)
-      socket.channels.add(spy)
+      socket.channels = socket.channels.copyAndRemove(channel)
+      socket.channels = socket.channels.copyAndAdd(spy)
 
       spy.join()
       assertThat(spy.state).isEqualTo(Channel.State.JOINING)
@@ -843,8 +844,8 @@ class SocketTest {
       val spy = spy(channel)
 
       // Use the spy instance instead of the Channel instance
-      socket.channels.remove(channel)
-      socket.channels.add(spy)
+      socket.channels = socket.channels.copyAndRemove(channel)
+      socket.channels = socket.channels.copyAndAdd(spy)
 
       spy.join().trigger("ok", emptyMap())
 
@@ -860,8 +861,8 @@ class SocketTest {
       val spy = spy(channel)
 
       // Use the spy instance instead of the Channel instance
-      socket.channels.remove(channel)
-      socket.channels.add(spy)
+      socket.channels = socket.channels.copyAndRemove(channel)
+      socket.channels = socket.channels.copyAndAdd(spy)
 
       spy.join().trigger("ok", emptyMap())
       spy.leave()
@@ -885,8 +886,8 @@ class SocketTest {
       val otherChannel = mock<Channel>()
       whenever(otherChannel.isMember(any())).thenReturn(false)
 
-      socket.channels.add(targetChannel)
-      socket.channels.add(otherChannel)
+      socket.channels = socket.channels.copyAndAdd(targetChannel)
+      socket.channels = socket.channels.copyAndRemove(otherChannel)
 
       val rawMessage =
           "{\"topic\":\"topic\",\"event\":\"event\",\"payload\":{\"one\":\"two\"},\"status\":\"ok\"}"

--- a/src/test/kotlin/org/phoenixframework/utilities/TestUtilities.kt
+++ b/src/test/kotlin/org/phoenixframework/utilities/TestUtilities.kt
@@ -6,3 +6,11 @@ import org.phoenixframework.Channel
 fun Channel.getBindings(event: String): List<Binding> {
   return bindings.toList().filter { it.event == event }
 }
+
+/** Converts the List to a MutableList, removes the value, and then returns as a read-only List */
+fun <T> List<T>.copyAndRemove(value: T): List<T> {
+  val temp = this.toMutableList()
+  temp.remove(value)
+
+  return temp
+}


### PR DESCRIPTION
There are still a few `ConcurrentModificationExceptions` occurring. These are caused by clients adding a callback hook inside of a callback hook or modifying the channels while handling an error, etc.

the solution is to make lists as read-only and then whenever adding or removing hooks and channels, use only concurrently safe operations by converting the read-only list to a new mutable list, adding the value, and then returning the new list.

This allows for looping over an existing list and adding a value to that list at the same time without modifying the underlying list while it's being looped over.