### PR TITLE
Allow passing Channel.Event to off

### DIFF
--- a/src/main/kotlin/org/phoenixframework/Channel.kt
+++ b/src/main/kotlin/org/phoenixframework/Channel.kt
@@ -293,6 +293,10 @@ class Channel(
     }
   }
 
+  fun off(event: Event, ref: Int? = null) {
+    this.off(event.value, ref)
+  }
+
   fun push(event: String, payload: Payload, timeout: Long = this.timeout): Push {
     if (!joinedOnce) {
       // If the Channel has not been joined, throw an exception


### PR DESCRIPTION
This allows developers to call

```Kotlin
channel.off(Channel.Event.REPLY, ref)
```

instead of 
```Kotlin
channel.off(Channel.Event.REPLY.value, ref)
// or
channel.off("phx_reply", ref)
```
