### PR TITLE
Allow providing params via a closure

### DIFF
--- a/src/test/kotlin/org/phoenixframework/ChannelTest.kt
+++ b/src/test/kotlin/org/phoenixframework/ChannelTest.kt
@@ -155,7 +155,7 @@ class ChannelTest {
 
     @BeforeEach
     internal fun setUp() {
-      socket = spy(Socket(url ="https://localhost:4000/socket", client = okHttpClient))
+      socket = spy(Socket(url = "https://localhost:4000/socket", client = okHttpClient))
       socket.dispatchQueue = fakeClock
       channel = Channel("topic", kDefaultPayload, socket)
     }


### PR DESCRIPTION
* Building `endpointUrl` using a closure to determine the params to be sent
* Changing the class constructor to accept a `payloadClosure` instead of just a `payload`
* Added a new alternate constructor to support the previous constructor which takes a constant or null payload

Closes #82 