### PR TITLE
Upgrade test dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,9 +54,9 @@ dependencies {
   testImplementation 'org.junit.jupiter:junit-jupiter-api:5.3.1'
   testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.3.1'
 
-  testCompile group: 'com.google.truth', name: 'truth', version: '0.44'
-  testCompile group: 'org.mockito', name: 'mockito-core', version: '2.27.0'
-  testCompile group: 'com.nhaarman.mockitokotlin2', name: 'mockito-kotlin', version: '2.1.0'
+  testCompile group: 'com.google.truth', name: 'truth', version: '1.1.3'
+  testCompile group: 'org.mockito', name: 'mockito-core', version: '4.0.0'
+  testCompile "org.mockito.kotlin:mockito-kotlin:4.0.0"
 }
 
 jacocoTestReport {

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
 
   testCompile group: 'com.google.truth', name: 'truth', version: '1.1.3'
   testCompile group: 'org.mockito', name: 'mockito-core', version: '4.0.0'
-  testCompile "org.mockito.kotlin:mockito-kotlin:4.0.0"
+  testCompile group: 'org.mockito.kotlin', name: 'mockito-kotlin', version: '4.0.0'
 }
 
 jacocoTestReport {

--- a/src/test/kotlin/org/phoenixframework/ChannelTest.kt
+++ b/src/test/kotlin/org/phoenixframework/ChannelTest.kt
@@ -1,14 +1,14 @@
 package org.phoenixframework
 
 import com.google.common.truth.Truth.assertThat
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.eq
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.never
-import com.nhaarman.mockitokotlin2.spy
-import com.nhaarman.mockitokotlin2.times
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.spy
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import okhttp3.OkHttpClient
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
-import org.mockito.Mockito.verifyZeroInteractions
+import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.MockitoAnnotations
 import org.phoenixframework.queue.ManualDispatchQueue
 import org.phoenixframework.utilities.getBindings
@@ -509,8 +509,8 @@ class ChannelTest {
             .receive("ok", mockOk)
             .receive("error", mockError)
             .receive("timeout") {
-              verifyZeroInteractions(mockOk)
-              verifyZeroInteractions(mockError)
+              verifyNoInteractions(mockOk)
+              verifyNoInteractions(mockError)
               timeoutReceived = true
             }
 
@@ -571,8 +571,8 @@ class ChannelTest {
         receivesTimeout()
 
         verify(mockError, times(1)).invoke(any())
-        verifyZeroInteractions(mockOk)
-        verifyZeroInteractions(mockTimeout)
+        verifyNoInteractions(mockOk)
+        verifyNoInteractions(mockTimeout)
       }
 
       @Test
@@ -619,7 +619,7 @@ class ChannelTest {
         channel.pushBuffer.add(mockPush)
 
         receivesError()
-        verifyZeroInteractions(mockPush)
+        verifyNoInteractions(mockPush)
         assertThat(channel.pushBuffer).hasSize(1)
       }
 
@@ -744,7 +744,7 @@ class ChannelTest {
       joinPush.trigger("ok", kEmptyPayload)
 
       assertThat(channel.state).isEqualTo(Channel.State.JOINED)
-      verifyZeroInteractions(mockCallback)
+      verifyNoInteractions(mockCallback)
 
       channel.trigger(Channel.Event.ERROR)
       verify(mockCallback, times(1)).invoke(any())
@@ -815,7 +815,7 @@ class ChannelTest {
     @Test
     internal fun `triggers additional callbacks`() {
       channel.onClose(mockCallback)
-      verifyZeroInteractions(mockCallback)
+      verifyNoInteractions(mockCallback)
 
       channel.trigger(Channel.Event.CLOSE)
       verify(mockCallback, times(1)).invoke(any())
@@ -907,8 +907,8 @@ class ChannelTest {
       channel.trigger(event = "event", ref = kDefaultRef)
       channel.trigger(event = "other", ref = kDefaultRef)
 
-      verifyZeroInteractions(callback1)
-      verifyZeroInteractions(callback2)
+      verifyNoInteractions(callback1)
+      verifyNoInteractions(callback2)
       verify(callback3, times(1)).invoke(any())
     }
 
@@ -923,7 +923,7 @@ class ChannelTest {
       channel.off("event", ref1)
       channel.trigger(event = "event", ref = kDefaultRef)
 
-      verifyZeroInteractions(callback1)
+      verifyNoInteractions(callback1)
       verify(callback2, times(1)).invoke(any())
     }
 
@@ -981,7 +981,7 @@ class ChannelTest {
           .receive("timeout", mockCallback)
 
       fakeClock.tick(channel.timeout / 2)
-      verifyZeroInteractions(mockCallback)
+      verifyNoInteractions(mockCallback)
 
       fakeClock.tick(channel.timeout)
       verify(mockCallback).invoke(any())
@@ -995,7 +995,7 @@ class ChannelTest {
           .receive("timeout", mockCallback)
 
       fakeClock.tick(channel.timeout)
-      verifyZeroInteractions(mockCallback)
+      verifyNoInteractions(mockCallback)
 
       fakeClock.tick(channel.timeout * 2)
       verify(mockCallback).invoke(any())
@@ -1009,12 +1009,12 @@ class ChannelTest {
           .receive("timeout", mockCallback)
 
       fakeClock.tick(channel.timeout / 2)
-      verifyZeroInteractions(mockCallback)
+      verifyNoInteractions(mockCallback)
 
       push.trigger("ok", kEmptyPayload)
 
       fakeClock.tick(channel.timeout)
-      verifyZeroInteractions(mockCallback)
+      verifyNoInteractions(mockCallback)
     }
 
     @Test

--- a/src/test/kotlin/org/phoenixframework/PresenceTest.kt
+++ b/src/test/kotlin/org/phoenixframework/PresenceTest.kt
@@ -1,8 +1,8 @@
 package org.phoenixframework
 
 import com.google.common.truth.Truth.assertThat
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.whenever
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested

--- a/src/test/kotlin/org/phoenixframework/SocketTest.kt
+++ b/src/test/kotlin/org/phoenixframework/SocketTest.kt
@@ -1,16 +1,16 @@
 package org.phoenixframework
 
 import com.google.common.truth.Truth.assertThat
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.argumentCaptor
-import com.nhaarman.mockitokotlin2.eq
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.never
-import com.nhaarman.mockitokotlin2.spy
-import com.nhaarman.mockitokotlin2.times
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.verifyZeroInteractions
-import com.nhaarman.mockitokotlin2.whenever
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.spy
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
 import okhttp3.OkHttpClient
 import okhttp3.Response
 import org.junit.jupiter.api.BeforeEach
@@ -363,7 +363,7 @@ class SocketTest {
     @Test
     internal fun `does nothing if not connected`() {
       socket.disconnect()
-      verifyZeroInteractions(connection)
+      verifyNoInteractions(connection)
     }
 
     /* End Disconnect */
@@ -664,7 +664,7 @@ class SocketTest {
       socket.skipHeartbeat = true
       socket.resetHeartbeat()
 
-      verifyZeroInteractions(mockDispatchQueue)
+      verifyNoInteractions(mockDispatchQueue)
     }
 
     @Test

--- a/src/test/kotlin/org/phoenixframework/TimeoutTimerTest.kt
+++ b/src/test/kotlin/org/phoenixframework/TimeoutTimerTest.kt
@@ -1,12 +1,12 @@
 package org.phoenixframework
 
 import com.google.common.truth.Truth
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.argumentCaptor
-import com.nhaarman.mockitokotlin2.eq
-import com.nhaarman.mockitokotlin2.times
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mock

--- a/src/test/kotlin/org/phoenixframework/WebSocketTransportTest.kt
+++ b/src/test/kotlin/org/phoenixframework/WebSocketTransportTest.kt
@@ -1,10 +1,10 @@
 package org.phoenixframework
 
 import com.google.common.truth.Truth.assertThat
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import okhttp3.OkHttpClient
 import okhttp3.Response
 import okhttp3.WebSocket


### PR DESCRIPTION
This PR upgrades mockito and google truth dependencies, since the tests were not running on the latest Android Studio otherwise.

`com.nhaarman.mockitokotlin2` is now `org.mockito.kotlin`