### PR TITLE
Fix webSocket not closed in onClosing

### DIFF
--- a/src/main/kotlin/org/phoenixframework/Transport.kt
+++ b/src/main/kotlin/org/phoenixframework/Transport.kt
@@ -155,6 +155,7 @@ class WebSocketTransport(
 
   override fun onClosing(webSocket: WebSocket, code: Int, reason: String) {
     this.readyState = Transport.ReadyState.CLOSING
+    webSocket.close(code, reason)
   }
 
   override fun onMessage(webSocket: WebSocket, text: String) {


### PR DESCRIPTION
Inside Android's Okhttp onClosing callback, we need to manually close the websocket, in order to trigger a reconnect. https://github.com/square/okhttp/issues/3386