### PR TITLE
Fix WebSocket not closed in onClosing

### DIFF
--- a/src/main/kotlin/org/phoenixframework/Transport.kt
+++ b/src/main/kotlin/org/phoenixframework/Transport.kt
@@ -155,6 +155,7 @@ class WebSocketTransport(
 
   override fun onClosing(webSocket: WebSocket, code: Int, reason: String) {
     this.readyState = Transport.ReadyState.CLOSING
+    webSocket.close(code, reason)
   }
 
   override fun onMessage(webSocket: WebSocket, text: String) {

--- a/src/test/kotlin/org/phoenixframework/WebSocketTransportTest.kt
+++ b/src/test/kotlin/org/phoenixframework/WebSocketTransportTest.kt
@@ -136,6 +136,7 @@ class WebSocketTransportTest {
       transport.readyState = Transport.ReadyState.OPEN
 
       transport.onClosing(mockWebSocket, 10, "reason")
+      verify(mockWebSocket).close(10, "reason")
       assertThat(transport.readyState).isEqualTo(Transport.ReadyState.CLOSING)
     }
 


### PR DESCRIPTION
This issue has a very serious impact on our project because after the screen is off for 30+ seconds, websocket stops receiving messages even after reconnecting.

This is the same as [Fix webSocket not closed in onClosing](https://github.com/dsrees/JavaPhoenixClient/pull/90) but with unit test updated.

> Inside Android's Okhttp onClosing callback, we need to manually close the websocket, in order to trigger a reconnect. https://github.com/square/okhttp/issues/3386

@dsrees Would you be able to accept and release this extremely important fix as soon as possible?

Thank you!