### PR TITLE
Fix the ability to set custom reconnectAfterMs

### DIFF
--- a/src/main/kotlin/org/phoenixframework/Socket.kt
+++ b/src/main/kotlin/org/phoenixframework/Socket.kt
@@ -273,7 +273,7 @@ class Socket(
     // Create reconnect timer
     this.reconnectTimer = TimeoutTimer(
       dispatchQueue = dispatchQueue,
-      timerCalculation = reconnectAfterMs,
+      timerCalculation = { reconnectAfterMs(it) },
       callback = {
         this.logItems("Socket attempting to reconnect")
         this.teardown { this.connect() }


### PR DESCRIPTION
Currently, setting custom `reconnectAfterMs` doesn't make sense since this var is applied to the `reconnectTimer` during the Socket class initializing.
The fix allows using custom `reconnectAfterMs` after the Socket object is created.